### PR TITLE
Fix sidebar navigation link

### DIFF
--- a/components/LinksGroup/LinksGroup.tsx
+++ b/components/LinksGroup/LinksGroup.tsx
@@ -1,6 +1,7 @@
 import {useState} from 'react';
 import {Box, Collapse, Group, rem, Text, ThemeIcon, UnstyledButton} from '@mantine/core';
 import {IconChevronRight} from '@tabler/icons-react';
+import Link from 'next/link';
 import classes from './LinksGroup.module.css';
 
 interface LinksGroupProps {
@@ -14,15 +15,11 @@ export const LinksGroup = ({icon: Icon, label, initiallyOpened, links}: LinksGro
     const hasLinks = Array.isArray(links);
     const [opened, setOpened] = useState(initiallyOpened || false);
     const items = (hasLinks ? links : []).map((link) => (
-        <Text<'a'>
-            component="a"
-            className={classes.link}
-            href={link.link}
-            key={link.label}
-            onClick={(event) => event.preventDefault()}
-        >
-            {link.label}
-        </Text>
+        <Link key={link.label} href={link.link} style={{ textDecoration: 'none' }}>
+            <Text className={classes.link}>
+                {link.label}
+            </Text>
+        </Link>
     ));
 
     return (


### PR DESCRIPTION
Replace `<a>` tags with `next/link` components to enable proper client-side navigation for sidebar items.

---
<a href="https://cursor.com/background-agent?bcId=bc-cfff51f1-1e11-4c74-9c81-b46e0e518f7a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cfff51f1-1e11-4c74-9c81-b46e0e518f7a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

