### PR TITLE
Fix mobile layout with Mantine

### DIFF
--- a/components/Navigation/Navigation.module.css
+++ b/components/Navigation/Navigation.module.css
@@ -1,4 +1,5 @@
 .navbar {
+    height: 100%;
     border-right: rem(1px) solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
 }
 

--- a/components/Navigation/Navigation.tsx
+++ b/components/Navigation/Navigation.tsx
@@ -43,7 +43,7 @@ export function NavbarNested() {
     const links = mockdata.map((item) => <LinksGroup {...item} key={item.label}/>);
 
     return (
-        <Box component={'nav'} className={classes.navbar} p={'md'} w={'300px'} h={'100vh'}>
+        <Box component={'nav'} className={classes.navbar}>
             <ScrollArea className={classes.links}>
                 <div>{links}</div>
             </ScrollArea>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,11 +1,14 @@
 import "@mantine/core/styles.css";
 import '@mantine/dates/styles.css';
 import Head from "next/head";
-import {Container, Flex, MantineProvider} from "@mantine/core";
+import {AppShell, Burger, Group, MantineProvider} from "@mantine/core";
 import {theme} from "../theme";
 import {NavbarNested} from "../components/Navigation/Navigation";
+import {useDisclosure} from '@mantine/hooks';
 
 export default function App({Component, pageProps}: any) {
+    const [opened, {toggle}] = useDisclosure();
+
     return (
         <MantineProvider theme={theme}>
             <Head>
@@ -17,12 +20,30 @@ export default function App({Component, pageProps}: any) {
                 <link rel="shortcut icon" href="/favicon.svg"/>
             </Head>
 
-            <Flex>
-                <NavbarNested/>
-                <Container my={'xl'}>
+            <AppShell
+                header={{height: 60}}
+                navbar={{
+                    width: 300,
+                    breakpoint: 'sm',
+                    collapsed: {mobile: !opened}
+                }}
+                padding="md"
+            >
+                <AppShell.Header>
+                    <Group h="100%" px="md">
+                        <Burger opened={opened} onClick={toggle} hiddenFrom="sm" size="sm" />
+                        <div>Quick Calculators</div>
+                    </Group>
+                </AppShell.Header>
+
+                <AppShell.Navbar p="md">
+                    <NavbarNested />
+                </AppShell.Navbar>
+
+                <AppShell.Main>
                     <Component {...pageProps} />
-                </Container>
-            </Flex>
+                </AppShell.Main>
+            </AppShell>
         </MantineProvider>
     );
 }


### PR DESCRIPTION
Refactor layout to use Mantine's AppShell to fix mobile responsiveness issues where sidebar and main content occupied 50% width.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac8d6726-0d3b-4c8f-8042-4c46fb8793f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ac8d6726-0d3b-4c8f-8042-4c46fb8793f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

